### PR TITLE
Added required "report_classification" property to "report_metadata"

### DIFF
--- a/optrs-schema-v1.json
+++ b/optrs-schema-v1.json
@@ -20,7 +20,8 @@
         "date_of_testing",
         "tester_info",
         "recipient",
-        "report_version"
+        "report_version",
+        "report_classification"
       ],
       "properties": {
         "report_id": { "type": "string", "format": "uuid" },
@@ -74,7 +75,8 @@
             }
           }
         },
-        "report_version": { "type": "string" }
+        "report_version": { "type": "string" },
+        "report_classification": { "type": "string", "enum": ["TLP:CLEAR", "TLP:GREEN", "TLP:AMBER", "TLP:RED", "Draft", "Confidential", "Public"] }
       }
     },
     "scope": {


### PR DESCRIPTION
Added required "report_classification" property to "report_metadata" following the FIRST Standards Definitions for TRAFFIC LIGHT PROTOCOL (TLP) from https://www.first.org/tlp/.

Alternatively, more generic classification values could be used like: Draft, Public, Confidential